### PR TITLE
Updated BaseQuery class

### DIFF
--- a/flask_python_ldap/__init__.py
+++ b/flask_python_ldap/__init__.py
@@ -110,7 +110,7 @@ class BaseQuery(object):
         if legacy:
             self._filter = legacy
             return self
-        self._filter = str()
+        self._filter = str() if not self._filter else self._filter
         for key, value in kwargs.items():
             splatted_key = key.split("__")
             if len(splatted_key) > 1:

--- a/flask_python_ldap/__init__.py
+++ b/flask_python_ldap/__init__.py
@@ -119,7 +119,7 @@ class BaseQuery(object):
                 attribute, compare = splatted_key[0], None
             if isinstance(value, list):
                 value = value[0]
-            if attribute in self.model._attr_defs.keys():
+            if attribute in self.model._attr_defs:
                 ldap_attribute_name = self.model._attr_defs[attribute].ldap_name
                 if compare:
                     if compare == "notequal":


### PR DESCRIPTION
Rewritten  filter() method which now provides DjangoORM-like filter construction and syntax. At the same time allows use native LDAP query syntax.
Signature: filter(legacy, **kwargs)
Returns: BaseQuery
Usage: entry_instance_list = EntryClass.query.filter(attr1[__filter]=value1, ...).all()