### PR TITLE
Updated BaseQuery class

### DIFF
--- a/flask_python_ldap/__init__.py
+++ b/flask_python_ldap/__init__.py
@@ -123,10 +123,10 @@ class BaseQuery(object):
         return self.model.from_search(*res[0]) if res else None
     
     def fields(self, *args):
-        self._attrlist = list()
-        for arg in args:
-            if arg in self.model._attr_defs:
-                self._attrlist.append(self.model._attr_defs[arg].ldap_name)
+        self._attrlist = [
+            self.model._attr_defs[arg].ldap_name for arg in args
+            if arg in self.model._attr_defs.keys()
+        ]
         return self
 
 

--- a/flask_python_ldap/__init__.py
+++ b/flask_python_ldap/__init__.py
@@ -125,7 +125,7 @@ class BaseQuery(object):
     def fields(self, *args):
         self._attrlist = list()
         for arg in args:
-            if arg in self.model._attr_defs.keys():
+            if arg in self.model._attr_defs:
                 self._attrlist.append(self.model._attr_defs[arg].ldap_name)
         return self
 


### PR DESCRIPTION
Added fields() method. Allows user to specify which field must be returned from OpenLDAP server.
Signature: fields(*args)
Usage: fields(field1, field2, ...)
Also rewritten _search() method for support this new feature